### PR TITLE
pep8, cleanup, error codes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,33 +1,32 @@
 #!/usr/bin/env python
-#
-# Copyright 2012 Major Hayden
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+"""
+Copyright 2012 Major Hayden
 
-"""MySQL <-> JSON bridge"""
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+MySQL <-> JSON bridge
+"""
 
 import datetime
 import decimal
 import json
 import logging
 import os
-import sys
 import yaml
 
-from flask import Flask, Response, abort, request
+from flask import Flask, make_response, Response, request
 from functools import wraps
 from torndb import Connection
-from urlparse import urlparse, urlunparse
 
 app = Flask(__name__)
 app.debug = True
@@ -63,15 +62,25 @@ if not app.debug:
 
 # Decorator to return JSON easily
 def jsonify(f):
+    """Decorator to return JSON easily."""
     @wraps(f)
     def inner(*args, **kwargs):
         # Change our datetime columns into strings so we can serialize
-        jsonstring = json.dumps(f(*args, **kwargs), default=json_fixup)
+        f_return = f(*args, **kwargs)
+
+        if len(f_return) > 1:
+            jsonstring = json.dumps(f_return[0], default=json_fixup)
+            resp = make_response(jsonstring, *f_return[1:])
+            resp.mimetype = 'application/json'
+            return resp
+
+        jsonstring = json.dumps(f_return, default=json_fixup)
         return Response(jsonstring, mimetype='application/json')
     return inner
 
 
 def json_fixup(obj):
+    """Perform type transformation on json."""
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
     if isinstance(obj, decimal.Decimal):
@@ -81,6 +90,7 @@ def json_fixup(obj):
 
 
 def read_config():
+    """Read Config from config directory."""
     databases = {}
     cfiles = []
 
@@ -92,10 +102,8 @@ def read_config():
 
     for cfile in cfiles:
         tmp = {}
-
         if not cfile.endswith('.yaml'):
             continue
-
         fh = open(data_file(cfile), 'r')
         db = yaml.load(fh)
         fh.close()
@@ -103,49 +111,46 @@ def read_config():
         if db is None:
             continue
 
-        if 'identifier' not in db:
+        required = [
+            'hostname',
+            'database',
+            'username',
+            'password',
+            'identifier',
+            'enabled'
+        ]
+
+        if not all(param in db for param in required):
             continue
 
-        if 'enabled' not in db:
-            continue
+        identifier = db.pop("identifier")
 
         if db['enabled'] != 'True':
             continue
 
-        identifier = db['identifier']
+        tmp[identifier] = db
 
-        required = ['scheme', 'username', 'password', 'hostname', 'database']
-        if not all(param in db for param in required):
-            continue
-
-        scheme = db['scheme']
-        netloc = '%s:%s@%s' % (db['username'], db['password'], db['hostname'])
-        path = '/%s' % db['database']
-        conn = (scheme, netloc, path, None, None, None)
-        connection_string = urlunparse(conn)
-
-        tmp[identifier] = connection_string
         databases = dict(databases.items() + tmp.items())
     return databases
 
 
 # Pull the database credentials from our YAML file
 def get_db_creds(database):
+    """Retrieve DB credentials."""
     databases = read_config()
-    mysql_uri = databases.get(database)
+    config = databases.get(database)
 
     # If the database doesn't exist in the yaml, we're done
-    if not mysql_uri:
+    if not config:
         return False
 
     # Parse the URL in the .yml file
     try:
-        o = urlparse(mysql_uri)
         creds = {
-            'host':         o.hostname,
-            'database':     o.path[1:],
-            'user':         o.username,
-            'password':     o.password,
+            'host': config["hostname"],
+            'database': config["database"],
+            'user': config["username"],
+            'password': config["password"],
         }
     except:
         creds = False
@@ -156,6 +161,7 @@ def get_db_creds(database):
 # Handles the listing of available databases
 @app.route("/list", methods=['GET'])
 def return_database_list():
+    """Return list of configured databases."""
     databases = read_config()
     data = {'databases': databases.keys()}
     return Response(json.dumps(data), mimetype='application/json')
@@ -165,15 +171,14 @@ def return_database_list():
 @app.route("/query/<database>", methods=['POST', 'GET'])
 @jsonify
 def do_query(database=None):
+    """Perform generic query on database."""
     # Pick up the database credentials
-    # app.logger.warning("%s requesting access to %s database" % (
-    #     request.remote_addr, database))
     creds = get_db_creds(database)
 
     # If we couldn't find corresponding credentials, throw a 404
     if not creds:
-        return {"ERROR": "Unable to find credentials matching %s." % database}
-        abort(404)
+        msg = "Unable to find credentials matching {0}."
+        return {"ERROR": msg.format(database)}, 404
 
     # Prepare the database connection
     app.logger.debug("Connecting to %s database (%s)" % (
@@ -185,7 +190,7 @@ def do_query(database=None):
     if not sql:
         sql = request.args.get('sql')
         if not sql:
-            return {"ERROR": "SQL query missing from request."}
+            return {"ERROR": "SQL query missing from request."}, 400
 
     # If the query has a percent sign, we need to excape it
     if '%' in sql:
@@ -198,7 +203,7 @@ def do_query(database=None):
         results = db.query(sql)
         app.logger.info(results)
     except Exception, e:
-        return {"ERROR": ": ".join(str(i) for i in e.args)}
+        return {"ERROR": ": ".join(str(i) for i in e.args)}, 422
 
     # Disconnect from the DB
     db.close()
@@ -209,15 +214,14 @@ def do_query(database=None):
 @app.route("/update/<database>", methods=['POST', 'GET'])
 @jsonify
 def do_update(database=None):
+    """Perform databse update."""
     # Pick up the database credentials
-    # app.logger.warning("%s requesting access to %s database" % (
-    #     request.remote_addr, database))
     creds = get_db_creds(database)
 
     # If we couldn't find corresponding credentials, throw a 404
     if not creds:
-        return {"ERROR": "Unable to find credentials matching %s." % database}
-        abort(404)
+        msg = "Unable to find credentials matching {0}."
+        return {"ERROR": msg.format(database)}, 404
 
     # Prepare the database connection
     app.logger.debug("Connecting to %s database (%s)" % (
@@ -229,7 +233,7 @@ def do_update(database=None):
     if not sql:
         sql = request.args.get('sql')
         if not sql:
-            return {"ERROR": "SQL query missing from request."}
+            return {"ERROR": "SQL query missing from request."}, 400
 
     # If the query has a percent sign, we need to excape it
     if '%' in sql:
@@ -242,7 +246,7 @@ def do_update(database=None):
         results = db.update(sql)
         app.logger.info(results)
     except Exception, e:
-        return {"ERROR": ": ".join(str(i) for i in e.args)}
+        return {"ERROR": ": ".join(str(i) for i in e.args)}, 422
 
     # Disconnect from the DB
     db.close()


### PR DESCRIPTION
# Changes:
- Altered jsonify decorator to allow make_response params to be passed in (allows flask style status code in return statements)
- Altered credential storage from url to dict (last commit silently removed this ability anyway, we can add it back in a future commit.)
- Added sane status codes to errors (400 for sql missing from params, 422 for mysql syntax error)
- Added docstrings to all functions for pep8
- A couple other miscellaneous pep8 fixes (line length, etc)

Thanks for looking!
